### PR TITLE
Fix unresponsive InlineKeyboardButton by answering callback queries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,8 @@ async fn answer(bot: Bot, msg: Message, bc: BCommand) -> ResponseResult<()> {
 }
 
 async fn handle_callback_query(bot: Bot, query: CallbackQuery) -> ResponseResult<()> {
+    bot.answer_callback_query(query.id.clone()).await?;
+
     match handle_callback_query_command_result(&bot, &query).await {
         Ok(msg) => match get_chat_id_and_username_from_query(&query) {
             Ok((chat_id, username)) => {


### PR DESCRIPTION
Added `answer_callback_query` to prevent InlineKeyboardButtons from staying in a non-responsive state. This fix involves only one line of code, as the goal is simply to resolve the button "loading" issue after user interaction.
